### PR TITLE
add a migration guide for common python-fedora methods

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,12 @@ on open-api specs (version 2.0).
 
    usage
 
+.. toctree::
+   :maxdepth: 2
+   :caption: Migration
+
+   migration
+
 
 .. Contributors
 

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -1,0 +1,72 @@
+Migrating from python-fedora
+----------------------------
+
+Fasjson-client provides functionality for the most important endpoints previously exposed in python-fedora.
+Below is a list of common python-fedora endpoints and their fasjson-client alternatives.
+
+
+Creating a client
+******************
+
+The instantiation of a client can be done similarly to python-fedora, except there is no need to provide a username and password with which to authenticate. Instead, this authentication is performed by your service via Kerberos.
+
+For more information, please see :ref:`usage-label`. The content below assumes you have setup your client as detailed in :ref:`usage-label`.
+
+Pagination is supported in some of the ``fasjson_client`` API calls listed below, for more information about how to use it see :ref:`pagination-label`.
+
+The following sections are divided by the objects requested, and each corresponding python-fedora method is listed as a heading - with the appropriate fasjson-client endpoint then explained below.
+
+Groups
+******
+
+group_by_id
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You must now use the ``groupname`` instead of ``id``. 
+
+    >>> client.get_group(groupname="testGroup").result
+    {'groupname': 'testGroup', 'uri': 'http://fasjson.example.test/fasjson/v1/groups/testGroup/'}
+
+group_by_name
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    >>> client.get_group(groupname="testGroup").result
+    {'groupname': 'testGroup', 'uri': 'http://fasjson.example.test/fasjson/v1/groups/testGroup/'}
+
+group_members
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    >>> client.get_group_members(groupname="testGroup", page_size=5).result
+    [{'username': 'user1', [...]}, {'username': 'user2', [...]}]
+
+People
+******
+
+person_by_id
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+You must now use the person's ``username`` instead of ``id``
+
+    >>> client.get_user(username="test").result
+    {'username': 'test', 'surname': 'user', 'givenname': 'test', 'emails': ['test@example.test'], 'ircnicks': ['test', 'test_1'], 'locale': 'en-US', 'timezone': None, 'gpgkeyids': None, 'certificates': None, 'creation': None, 'locked': False, 'uri': 'http://fasjson.example.test/fasjson/v1/users/test/'}
+
+
+person_by_username
+~~~~~~~~~~~~~~~~~~
+
+    >>> client.get_user(username="test").result
+    {'username': 'test', 'surname': 'user', 'givenname': 'test', 'emails': ['test@example.test'], 'ircnicks': ['test', 'test_1'], 'locale': 'en-US', 'timezone': None, 'gpgkeyids': None, 'certificates': None, 'creation': None, 'locked': False, 'uri': 'http://fasjson.example.test/fasjson/v1/users/test/'}
+
+
+user_data
+~~~~~~~~~~~~~~
+
+    >>> client.list_users(page_size=50).result
+    [{'username': 'user1', [...]}, {'username': 'user2', [...]}]
+
+
+people_by_groupname
+~~~~~~~~~~~~~~~~~~~
+
+    >>> client.get_group_members(groupname="testGroup", page_size=5).result
+    [{'username': 'user1', [...]}, {'username': 'user2', [...]}]

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,5 +1,8 @@
+.. _usage-label:
+
 Usage
 -----
+
 
 Instantiate the client with the FASJSON URL you want to use::
 
@@ -75,6 +78,8 @@ For example::
 
 Your service should now be able to authenticate with Kerberos
 
+
+.. _pagination-label:
 
 Pagination
 ----------


### PR DESCRIPTION
This commit adds a very basic migration guide which just maps the commonly used methods in python-fedora to this client.

Signed-off-by: Stephen Coady <scoady@redhat.com>