### PR TITLE
Add a method to get all users in one call but multiple requests

### DIFF
--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -22,7 +22,7 @@ Groups
 group_by_id
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You must now use the ``groupname`` instead of ``id``. 
+You must now use the ``groupname`` instead of ``id``.
 
     >>> client.get_group(groupname="testGroup").result
     {'groupname': 'testGroup', 'uri': 'http://fasjson.example.test/fasjson/v1/groups/testGroup/'}
@@ -70,3 +70,19 @@ people_by_groupname
 
     >>> client.get_group_members(groupname="testGroup", page_size=5).result
     [{'username': 'user1', [...]}, {'username': 'user2', [...]}]
+
+
+Getting all items at once
+*************************
+
+The ``list_all_entities`` method is an iterator over all records of an entity in FASJSON, for
+example ``users`` or ``groups``. They will be retrieved in multiple server calls (using pagination).
+You can specify the number of users that should be returned in each server call in the ``page_size``
+argument if you have performance issues, but the default should be fine. An example with users::
+
+    >>> for user in client.list_all_entities("users", page_size=1000):
+    ...     print(user)
+    {'username': 'user1', [...]}
+    {'username': 'user2', [...]}
+    {'username': 'user3', [...]}
+    [...]

--- a/fasjson_client/client.py
+++ b/fasjson_client/client.py
@@ -90,3 +90,18 @@ class Client:
             return self._ops[name]
         except KeyError:
             raise AttributeError("No such operation: {!r}".format(name))
+
+    def list_all_entities(self, entity_name, page_size=1000):
+        try:
+            operation = self._ops["list_{}".format(entity_name)]
+        except KeyError:
+            raise ValueError(
+                "No such entity: {}. Is it plural? It should be.".format(entity_name)
+            )
+        page_number = 0
+        next_page_exists = True
+        while next_page_exists:
+            page_number += 1
+            response = operation(page_size=page_size, page_number=page_number)
+            yield from response.result
+            next_page_exists = page_number < response.page["total_pages"]

--- a/fasjson_client/tests/unit/test_client_api.py
+++ b/fasjson_client/tests/unit/test_client_api.py
@@ -60,3 +60,51 @@ def test_api_error_text(server):
     assert exc.code == 500
     assert exc.message == "500 Server Error: Internal Server Error"
     assert exc.data.get("body") == "Internal Server Error"
+
+
+def test_get_all_users(server):
+    mocked = [
+        dict(
+            json={
+                "result": [{"username": "dummy-01"}, {"username": "dummy-02"}],
+                "page": {"page_number": 1, "page_size": 2, "total_pages": 3},
+            },
+        ),
+        dict(
+            json={
+                "result": [{"username": "dummy-03"}, {"username": "dummy-04"}],
+                "page": {"page_number": 2, "page_size": 2, "total_pages": 3},
+            },
+        ),
+        dict(
+            json={
+                "result": [{"username": "dummy-05"}],
+                "page": {"page_number": 3, "page_size": 2, "total_pages": 3},
+            },
+        ),
+    ]
+    server.mock_endpoint("/users/", mocked, method="GET")
+    client = Client("http://example.com/fasjson")
+    result = client.list_all_entities("users", page_size=2)
+    assert list(result) == [{"username": f"dummy-0{i}"} for i in range(1, 6)]
+
+
+def test_get_all_groups(server):
+    mocked = [
+        dict(
+            json={
+                "result": [{"groupname": "dummy"}],
+                "page": {"page_number": 1, "total_pages": 1},
+            },
+        ),
+    ]
+    server.mock_endpoint("/groups/", mocked, method="GET")
+    client = Client("http://example.com/fasjson")
+    result = client.list_all_entities("groups")
+    assert list(result) == [{"groupname": "dummy"}]
+
+
+def test_list_all_entities_wrong_name(server):
+    client = Client("http://example.com/fasjson")
+    with pytest.raises(ValueError):
+        list(client.list_all_entities("foobar"))


### PR DESCRIPTION
Many apps are apparently caching the whole list of users for their own lookup purposes. While the relevance of that can be questioned with the new LDAP backend (that should be much faster), for migration purposes it could be useful to centralize the proper way to get all users instead of having that code duplicated in many apps.

What do you think @StephenCoady ?