### PR TITLE
Loosen version reqs for some dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,11 +42,11 @@ click = {version = "^6.7 || ^7", optional = true}
 toml = "^0.10.1"
 
 [tool.poetry.dev-dependencies]
-coverage = "^5.1"
+coverage = "^5.0.3"
 flake8 = "^3.7.9"
-pytest = "^5.4.1 || ^6"
+pytest = "^4.6.11 || ^5 || ^6"
 pytest-cov = "^2.8.1"
-pytest-mock = "^3.1.0"
+pytest-mock = "^1.10.4 || ^2 || ^3"
 requests-mock = "^1.7"
 sphinx = "^3.0.2"
 sphinxcontrib-httpdomain = "^1.7.0"


### PR DESCRIPTION
Fedora 32 has older versions of coverage, pytest, pytest-mock but they
seem to work fine in unit tests.

Signed-off-by: Nils Philippsen <nils@redhat.com>