### PR TITLE
Adjust the documentation and test to say list_group_members

### DIFF
--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -36,7 +36,7 @@ group_by_name
 group_members
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-    >>> client.get_group_members(groupname="testGroup", page_size=5).result
+    >>> client.list_group_members(groupname="testGroup", page_size=5).result
     [{'username': 'user1', [...]}, {'username': 'user2', [...]}]
 
 People
@@ -68,7 +68,7 @@ user_data
 people_by_groupname
 ~~~~~~~~~~~~~~~~~~~
 
-    >>> client.get_group_members(groupname="testGroup", page_size=5).result
+    >>> client.list_group_members(groupname="testGroup", page_size=5).result
     [{'username': 'user1', [...]}, {'username': 'user2', [...]}]
 
 

--- a/fasjson_client/tests/unit/fixtures/spec.json
+++ b/fasjson_client/tests/unit/fixtures/spec.json
@@ -368,7 +368,7 @@
         },
         "/groups/{groupname}/members/": {
             "get": {
-                "operationId": "get_group_members",
+                "operationId": "list_group_members",
                 "parameters": [
                     {
                         "description": "Page size.",

--- a/fasjson_client/tests/unit/test_client_api.py
+++ b/fasjson_client/tests/unit/test_client_api.py
@@ -26,7 +26,7 @@ def test_api_list_operations(server):
         "get_cert",
         "list_groups",
         "get_group",
-        "get_group_members",
+        "list_group_members",
         "whoami",
         "list_users",
         "get_user",


### PR DESCRIPTION
The get_group_members is no longer valid.

Signed-off-by: Pierre-Yves Chibon <pingou@pingoured.fr>