### PR TITLE
Revert "tox: Don't install the root package"

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,17 +10,17 @@ whitelist_externals =
     rm
 commands =
     rm -rf htmlcov coverage.xml
-    poetry install -E cli -q --no-root
+    poetry install -E cli -q
     poetry run pytest -vv --cov --cov-report term-missing --cov-report xml --cov-report html fasjson_client/tests/unit {posargs}
 
 [testenv:lint]
 commands =
-    poetry install -q --no-root
+    poetry install -q
     poetry run flake8 {posargs}
 
 [testenv:format]
 commands =
-    poetry install -q --no-root
+    poetry install -q
     poetry run black --check --diff {posargs:.}
 
 [testenv:docs]
@@ -33,7 +33,7 @@ whitelist_externals =
 commands=
     mkdir -p _static
     rm -rf _build
-    poetry install -q --no-root
+    poetry install -q
     poetry run sphinx-build -W -b html -d {envtmpdir}/doctrees .  _build/html
 
 [testenv:licenses]
@@ -41,7 +41,7 @@ commands=
 # flake8 requires importlib_metadata on python < 3.8, so it's not installed, but it's exported
 # and liccheck crashes on packages listed in the req file but not installed.
 commands =
-    poetry install -E cli -q --no-root
+    poetry install -E cli -q
     #poetry export -E cli -f requirements.txt -o /tmp/fasjson-client-requirements.txt
     bash -c "pip freeze --exclude-editable --isolated > /tmp/fasjson-client-requirements.txt"
     poetry run liccheck -r /tmp/fasjson-client-requirements.txt
@@ -53,7 +53,7 @@ whitelist_externals =
 
 [testenv:bandit]
 commands =
-    poetry install -q --no-root
+    poetry install -q
     poetry run bandit -r fasjson_client/ -x fasjson_client/tests/ -ll
 
 [flake8]


### PR DESCRIPTION
This reverts commit f763bfc210e5c1d3065223aa8aab91acddc7453f.

Not installing the root package breaks the version detection in `fasjson_client/__init__.py`.