### PR TITLE
Support cryptography version 35

### DIFF
--- a/fasjson_client/cli/get_cert.py
+++ b/fasjson_client/cli/get_cert.py
@@ -43,7 +43,11 @@ def _load_private_key(path):
                 key_file.read(), password=None, backend=default_backend()
             )
         except ValueError as e:
-            raise click.ClickException("can't load the private key: {!s}".format(e))
+            if e.args:
+                e_str = "\n".join(str(arg) for arg in e.args)
+            else:
+                e_str = "unknown error"
+            raise click.ClickException(f"can't load the private key: {e_str}")
     return private_key
 
 

--- a/fasjson_client/tests/unit/test_cli_get_cert.py
+++ b/fasjson_client/tests/unit/test_cli_get_cert.py
@@ -262,5 +262,5 @@ def test_sign_bad_pkey(invoker, tmp_path, mocker, fixture_dir):
         " The data may be in an incorrect format or it may be encrypted with"
         " an unsupported algorithm.\n",
     )
-    assert result.output in expected_msgs
+    assert any(result.output.startswith(msg) for msg in expected_msgs)
     make_csr.assert_not_called()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ gssapi = "^1.5.1"
 bravado = "^10.6.0 || ^11"
 requests = "^2.20.0"
 requests-gssapi = "^1.2.1"
-cryptography = {version = "^2.3 || ^3", optional = true}
+cryptography = {version = "^2.3 || ^3 || ^35", optional = true}
 click = {version = "^6.7 || ^7 || ^8", optional = true}
 toml = "^0.10.0"
 


### PR DESCRIPTION
This version adds the underlying OpenSSL error to ValueErrors raised
when loading erroneous keys.

Format that a little nicer for users and cope with it in tests.

Signed-off-by: Nils Philippsen <nils@redhat.com>