### PR TITLE
add and configure packit

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,91 @@
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+
+specfile_path: python-fasjson-client.spec
+
+# add or remove files that should be synced
+files_to_sync:
+    - python-fasjson-client.spec
+    - .packit.yaml
+
+# name in upstream package repository or registry (e.g. in PyPI)
+upstream_package_name: fasjson-client
+# downstream (Fedora) RPM package name
+downstream_package_name: python-fasjson-client
+
+srpm_build_deps:
+  - wget
+
+actions:
+    create-archive:
+        - "poetry build -f sdist"
+        - "sh -c 'echo dist/fasjson-client-$(poetry version -s).tar.gz'"
+    get-current-version:
+        - "poetry version -s"
+    post-upstream-clone:
+        - "wget https://src.fedoraproject.org/rpms/python-fasjson-client/raw/main/f/python-fasjson-client.spec -O python-fasjson-client.spec"
+         # we need poetry v1.1.7 because of a bug in 1.1.8 where python evaluates incorrectly
+        - "sh -c 'wget https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py && python3 install-poetry.py --version 1.1.7 && rm install-poetry.py'"
+
+jobs:
+  # upon upstream PRs, perform copr builds
+  - job: copr_build
+    trigger: pull_request
+    metadata:
+      targets:
+        - fedora-latest-stable
+        - fedora-development
+
+  - job: tests
+    trigger: pull_request
+    metadata:
+      targets:
+        - fedora-latest-stable
+        - fedora-development
+
+  # upon upstream release, perform copr builds
+  - job: copr_build
+    trigger: release
+    metadata:
+      targets:
+        - fedora-latest-stable
+        - fedora-development
+      project: fasjson-client
+
+  # upon downstream changes, create a PR upstream with sync'd files from above
+  - job: sync_from_downstream
+    trigger: commit
+
+  # land upstream release in fedora dist-git - no builds
+  - job: propose_downstream
+    trigger: release
+    metadata:
+      dist_git_branches:
+        - fedora-latest-stable
+        - fedora-development
+
+  # create an srpm from upstream and submit a scratch build to koji
+  - job: production_build
+    trigger: release
+    metadata:
+      targets:
+        - fedora-latest-stable
+        - fedora-development
+
+  # downstream automation
+
+  # trigger a build in koji for a new dist-git commit
+  - job: koji_build
+    trigger: commit
+    metadata:
+      dist_git_branches:
+        - fedora-latest-stable
+        - fedora-development
+
+  # create a new update in bodhi for a successful koji build. directly related to `koji_build`
+  - job: bodhi_update
+    trigger: commit
+    metadata:
+      dist_git_branches:
+        - fedora-latest-stable
+        - fedora-development


### PR DESCRIPTION
this commit add configuration for the packit service.
this will enable automatic copr builds for PRs and releases.

it also enables some downstream automation in koji and bodhi which
will trigger downstream changes in dist git upon commits there.
upstream builds to koji are submitted in the form of scratch builds.

Signed-off-by: Stephen Coady <scoady@redhat.com>