### PR TITLE
Add upstream version format

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -14,6 +14,7 @@ files_to_sync:
 upstream_package_name: fasjson-client
 # downstream (Fedora) RPM package name
 downstream_package_name: python-fasjson-client
+upstream_tag_template: v{version}
 
 srpm_build_deps:
   - wget


### PR DESCRIPTION
Signed-off-by: Akashdeep Dhar <akashdeep.dhar@gmail.com>

Should allow for tags to have a `v` prefix, much unlike the https://github.com/fedora-infra/fasjson-client/releases/tag/1.0.7 which does not seem to have one. 