### PR TITLE
Use poetry-core as the build backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,5 +95,5 @@ authorized_licenses = [
 ]
 
 [build-system]
-requires = ["poetry>=1.0.0"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
poetry-core has far fewer dependencies than poetry.  It's maintained by the same people and poetry itself uses poetry-core.  Switching to this makes packaging easier.  See rhbz#2049649 for more details.