### PR TITLE
Point tox-github-action to the correct branch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Run tests
-        uses: fedora-python/tox-github-action@master
+        uses: fedora-python/tox-github-action@main
         with:
           tox_env: ${{ matrix.tox_env }}
           dnf_install: krb5-devel openldap-devel libffi-devel poetry
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Run tests
-        uses: fedora-python/tox-github-action@master
+        uses: fedora-python/tox-github-action@main
         with:
           tox_env: ${{ matrix.tox_env }}
           dnf_install: krb5-devel openldap-devel libffi-devel poetry


### PR DESCRIPTION
Tox-github-action branch is now named main
As seen here: https://github.com/fedora-python/tox-github-action